### PR TITLE
[FIXME] Make finalize_helper.firm not installable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ builds/finalize_helper.firm: builds/finalize.romfs
 	@sed -i s/FINALIZE_SHA256SUM/$(shell sha256sum $< | awk '{print $$1}')/g GodMode9/data/autorun.gm9
 	@$(MAKE) -C GodMode9 SCRIPT_RUNNER=1
 	@cp GodMode9/output/GodMode9.firm $@
-
+	@printf '\x01' | dd conv=notrunc bs=1 seek=16 of=$@
 clean:
 	@rm -rf builds
 	@$(MAKE) -C GodMode9 clean


### PR DESCRIPTION
This sets flag for screeninit with dd, which makes GodMode9s installable check fail. It has no impact on the behaviour of the helper. 

This will prevent some "bricks" from people who attempt to install the helper and it shouldnt be installable anyway. 